### PR TITLE
Fix scheduler bug.

### DIFF
--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -191,7 +191,7 @@ def schedule_graph(G, scheduler, metadata):
     # could move the tasks themselves - in this case, push things into the future).
     for task in G.nodes:
         if task.start_date is not None and task.end_date is not None:
-            scheduler(G, task, False, metadata)
+            scheduler(G, task, True, metadata)
 
     # Now, back propagate dates (so end dates can be based on start dates of successor tasks).
     #


### PR DESCRIPTION
The scheduler’s first pass - assigning people to dates for tasks that are manually scheduled - needs to use the backwards calendar, not the forwards one. We don’t expect any conflicts until we do the forwards pass at the end (which uses a clean calendar rather than the one built up based on manually scheduled tasks and the backwards pass). The reason for this is it’s more useful to see conflicts between “start now” and “finish by X” rather than just having forward scheduled tasks slide to the very end of the project.